### PR TITLE
Update installation instructions to include configuration copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Install and watch assets:
     $ grunt
     $ grunt watch
 
+Configure the application by copying the skeleton file and editing it:
+
+    $ cp app/config/parameters.yml.dist app/config/parameters.yml
+    $ vi app/config/parameters.yml
+
 License
 -------
 


### PR DESCRIPTION
The application cannot run without having copied the configuration and the
web interface does not warn about the missing configuration.

By adding this to the README file it will reduce the amount of friction
that potential users will experience.
