### PR TITLE
Add Exec task

### DIFF
--- a/spec/F500/CI/Task/Exec/ExecTaskSpec.php
+++ b/spec/F500/CI/Task/Exec/ExecTaskSpec.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * This file is part of the Future CI package.
+ * Future CI is licensed under MIT (https://github.com/f500/future-ci/blob/master/LICENSE).
+ */
+
+namespace spec\F500\CI\Task\Exec;
+
+use F500\CI\Build\Build;
+use F500\CI\Command\Command;
+use F500\CI\Command\CommandFactory;
+use F500\PhpSpec\Doubler;
+use Prophecy\Argument;
+use spec\F500\CI\Task\TaskSpec;
+
+/**
+ * Class ExecTaskSpec
+ *
+ * @copyright 2014 Future500 B.V.
+ * @license   https://github.com/f500/future-ci/blob/master/LICENSE MIT
+ * @package   spec\F500\CI\Task
+ */
+class ExecTaskSpec extends TaskSpec
+{
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('F500\CI\Task\Exec\ExecTask');
+        $this->shouldImplement('F500\CI\Task\Task');
+    }
+
+    function it_has_default_options()
+    {
+        $options = array(
+            'cwd'         => '',
+            'env'         => array(),
+            'bin'         => null,
+            'args'        => array(),
+        );
+
+        $this->getOptions()->shouldReturn($options);
+    }
+
+    function it_has_other_options_after_setting_them()
+    {
+        $options = array(
+            'cwd'         => '',
+            'env'         => array(),
+            'bin'         => 'ls',
+            'args'        => array('-v'),
+            'foo'         => 'bar'
+        );
+
+        $newoptions = array(
+            'bin'  => 'ls',
+            'args' => array('-v'),
+            'foo'  => 'bar'
+        );
+
+        $this->setOptions($newoptions);
+        $this->getOptions()->shouldReturn($options);
+    }
+
+    function it_builds_commands(Build $build, CommandFactory $commandFactory, Command $command)
+    {
+        $commandFactory->createCommand()->will(
+            function () use ($command) {
+                $this->createCommand()->willReturn($command);
+
+                return $command;
+            }
+        );
+
+        Doubler::get()->stubCommand($command);
+
+        $this->setOptions(array('bin' => 'ls', 'args' => array('-lha')));
+
+        $commands = $this->buildCommands($build, $commandFactory);
+        $commands->shouldBe(array($command));
+
+        $commands[0]->getArgs()->shouldReturn(
+            array('ls', '-lha')
+        );
+    }
+}

--- a/src/F500/CI/Task/Exec/ExecTask.php
+++ b/src/F500/CI/Task/Exec/ExecTask.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This file is part of the Future CI package.
+ * Future CI is licensed under MIT (https://github.com/f500/future-ci/blob/master/LICENSE).
+ */
+
+namespace F500\CI\Task\Exec;
+
+use F500\CI\Build\Build;
+use F500\CI\Command\Command;
+use F500\CI\Command\CommandFactory;
+use F500\CI\Task\BaseTask;
+
+/**
+ * Task used to execute a shell command.
+ *
+ * @copyright 2014 Future500 B.V.
+ * @license   https://github.com/f500/future-ci/blob/master/LICENSE MIT
+ * @package   F500\CI\Task
+ */
+class ExecTask extends BaseTask
+{
+
+    /**
+     * Initializes the commands for this task.
+     *
+     * @param Build          $build
+     * @param CommandFactory $commandFactory
+     *
+     * @return Command[]
+     */
+    public function buildCommands(Build $build, CommandFactory $commandFactory)
+    {
+        return array($this->createCommand($commandFactory));
+    }
+
+    /**
+     * Generates a command that can be performed on the target location using the provided options.
+     *
+     * This command will run the binary provided using the "bin" option together with a series of arguments
+     * provided by the "args" option (array). You can control from where this is executed by providing an option "cwd"
+     * that will first navigate to the given location before executing the provided binary.
+     *
+     * @param CommandFactory $commandFactory
+     *
+     * @throws \Exception if no "bin" option is provided; this is required.
+     *
+     * @return Command
+     */
+    protected function createCommand(CommandFactory $commandFactory)
+    {
+        $options = $this->getOptions();
+        $command = $commandFactory->createCommand();
+
+        if ( ! $options['bin']) {
+            throw new \Exception('The "bin" option is required for the "Exec" task');
+        }
+
+        $command->addArg($options['bin']);
+        foreach ($options['args'] as $arg) {
+            $command->addArg($arg);
+        }
+
+        if ( ! empty($options['cwd'])) {
+            $command->setCwd($options['cwd']);
+        }
+
+        if (! empty($options['env'])) {
+            foreach ($options['env'] as $name => $value) {
+                $command->addEnv($name, $value);
+            }
+        }
+
+        return $command;
+    }
+
+    /**
+     * Returns the defaults for all supported options.
+     *
+     * @return mixed[]
+     */
+    protected function getDefaultOptions()
+    {
+        return array(
+            'cwd'         => '',      // Current working directory for this task.
+            'env'         => array(), // environment in which to run.
+            'bin'         => null,    // the full path to the binary that needs to be run; use /usr/bin/env if unsure
+                                      // where it is
+            'args'        => array(), // a series of options and arguments (should include and prefixing hyphens).
+        );
+    }
+}


### PR DESCRIPTION
In order to remote execute arbitrary commands a new task needed to be added
to the list of tasks.

I have tested this using a suite that contained the following task definition:

```
    test_exec:
      class: F500\CI\Task\Exec\ExecTask
      name: Run exec test
      cwd: %remote_root_dir%
      bin: ls
      args: ['-lha']
      parsers:
        always_pass:
          class: F500\CI\Task\AlwaysPassResultParser
      wrappers: [ansible]
```

And I verified the output by checking var/logs/app.dev.log
