### PR TITLE
Change Codeception to output in XML

### DIFF
--- a/spec/F500/CI/Task/Codeception/CodeceptionResultParserSpec.php
+++ b/spec/F500/CI/Task/Codeception/CodeceptionResultParserSpec.php
@@ -23,51 +23,37 @@ use spec\F500\CI\Task\ResultParserSpec;
 class CodeceptionResultParserSpec extends ResultParserSpec
 {
 
-    protected $passedReport = <<<'EOT'
-{
-    "event": "suiteStart",
-    "suite": "acceptance",
-    "tests": 1
-}{
-    "event": "testStart",
-    "suite": "acceptance",
-    "test": "some_test (SomeTest.php)"
-}{
-    "event": "test",
-    "suite": "acceptance",
-    "test": "some_test (SomeTest.php)",
-    "status": "pass",
-    "time": 1.2345678909876,
-    "trace": [
+    protected $passedReport = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="unit" tests="10" assertions="11" failures="1" errors="1" time="0.141928">
+    <testcase name="testTypesCanBeRetrievedByName" class="Notification\\ManagerTest" file="/vagrant-poolz-app/tests/unit/Notification/ManagerTest.php" line="62" assertions="2" time="0.005319"/>
+  </testsuite>
+</testsuites>
+XML;
 
-    ],
-    "message": "",
-    "output": ""
-}
-EOT;
 
-    protected $failedReport = <<<'EOT'
-{
-    "event": "suiteStart",
-    "suite": "acceptance",
-    "tests": 1
-}{
-    "event": "testStart",
-    "suite": "acceptance",
-    "test": "some_test (SomeTest.php)"
-}{
-    "event": "test",
-    "suite": "acceptance",
-    "test": "some_test (SomeTest.php)",
-    "status": "fail",
-    "time": 1.2345678909876,
-    "trace": [
+    protected $failedReport = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="unit" tests="10" assertions="11" failures="1" errors="1" time="0.141928">
+    <testcase name="testTypesCanBeRegistered" class="Notification\\ManagerTest" file="/vagrant-poolz-app/tests/unit/Notification/ManagerTest.php" line="36" assertions="1" time="0.061458">
+      <failure type="PHPUnit_Framework_ExpectationFailedException">Notification\\ManagerTest::testTypesCanBeRegistered
+Failed asserting that actual size 0 matches expected size 1.
 
-    ],
-    "message": "",
-    "output": ""
-}
-EOT;
+/vagrant-poolz-app/tests/unit/Notification/ManagerTest.php:38
+</failure>
+    </testcase>
+    <testcase name="testTypesCanBeRetrieved" class="Notification\\ManagerTest" file="/vagrant-poolz-app/tests/unit/Notification/ManagerTest.php" line="49" assertions="0" time="0.005097">
+      <error type="PHPUnit_Framework_ExceptionWrapper">Notification\\ManagerTest::testTypesCanBeRetrieved
+Exception:
+
+</error>
+    </testcase>
+    <testcase name="testTypesCanBeRetrievedByName" class="Notification\\ManagerTest" file="/vagrant-poolz-app/tests/unit/Notification/ManagerTest.php" line="62" assertions="2" time="0.005319"/>
+  </testsuite>
+</testsuites>
+XML;
 
     function it_is_initializable()
     {
@@ -79,7 +65,6 @@ EOT;
     {
         $filesystem->exists(Argument::type('string'))->willReturn(true);
         $filesystem->readFile(Argument::type('string'))->willReturn($this->passedReport);
-        $filesystem->dumpFile(Argument::type('string'), Argument::type('string'))->willReturn();
 
         $result->getBuildDir($task)->willReturn('/path/to/build');
         $result->getFilesystem()->willReturn($filesystem);
@@ -94,7 +79,6 @@ EOT;
     {
         $filesystem->exists(Argument::type('string'))->willReturn(true);
         $filesystem->readFile(Argument::type('string'))->willReturn($this->failedReport);
-        $filesystem->dumpFile(Argument::type('string'), Argument::type('string'))->willReturn();
 
         $result->getBuildDir($task)->willReturn('/path/to/build');
         $result->getFilesystem()->willReturn($filesystem);

--- a/spec/F500/CI/Task/Codeception/CodeceptionTaskSpec.php
+++ b/spec/F500/CI/Task/Codeception/CodeceptionTaskSpec.php
@@ -123,7 +123,7 @@ class CodeceptionTaskSpec extends TaskSpec
                 '--no-ansi',
                 '--no-interaction',
                 'run',
-                '--json',
+                '--xml',
                 '--silent',
                 '--no-exit'
             )

--- a/src/F500/CI/Task/Codeception/CodeceptionResultParser.php
+++ b/src/F500/CI/Task/Codeception/CodeceptionResultParser.php
@@ -8,69 +8,80 @@
 namespace F500\CI\Task\Codeception;
 
 use F500\CI\Build\Result;
-use F500\CI\Filesystem\Filesystem;
 use F500\CI\Task\BaseResultParser;
 use F500\CI\Task\Task;
-use Symfony\Component\Filesystem\Exception\IOException;
 
 /**
- * Class CodeceptionResultParser
+ * Parses the report.xml file in the Build Directory for any errors or failures and marks the current task as failed if
+ * any are found.
  *
  * @copyright 2014 Future500 B.V.
  * @license   https://github.com/f500/future-ci/blob/master/LICENSE MIT
  * @package   F500\CI\Task\Result
  */
-class CodeceptionResultParser extends BaseResultParser
+final class CodeceptionResultParser extends BaseResultParser
 {
-
     /**
+     * Loads the report and marks the tasks as passed or failed based on whether the report contains failures or errors.
+     *
      * @param Task   $task
      * @param Result $result
+     *
+     * @return void
      */
     public function parse(Task $task, Result $result)
     {
-        $report = $this->fixReport($result->getBuildDir($task), $result->getFilesystem());
-        $report = json_decode($report, true);
+        $report = $this->loadReport($task, $result);
 
-        $passed = true;
-        foreach ($report as $item) {
-            if ($item['event'] == 'test' && $item['status'] !== 'pass') {
-                $passed = false;
-                break;
-            }
-        }
-
-        if ($passed) {
-            $result->markTaskAsPassed($task);
-        } else {
+        if (count($this->fetchAllFailuresAndErrors($report)) > 0) {
             $result->markTaskAsFailed($task);
+        } else {
+            $result->markTaskAsPassed($task);
         }
     }
 
     /**
-     * @param string     $buildDir
-     * @param Filesystem $filesystem
-     * @return false|string
+     * Loads the 'report.xml' file from the build directory and returns it as a SimpleXMLElement.
+     *
+     * @param Task   $task
+     * @param Result $result
+     *
+     * @return \SimpleXMLElement
      */
-    protected function fixReport($buildDir, Filesystem $filesystem)
+    private function loadReport(Task $task, Result $result)
     {
-        $filename = $buildDir . '/report.json';
+        $filename = $this->getReportFilename($task, $result);
 
-        if (!$filesystem->exists($filename)) {
-            return false;
+        $filesystem = $result->getFilesystem();
+        if ( ! $filesystem->exists($filename)) {
+            throw new \InvalidArgumentException("The report '$filename' could not be found on the filesystem");
         }
 
-        try {
-            $report = $filesystem->readFile($filename);
+        return simplexml_load_string($filesystem->readFile($filename));
+    }
 
-            $report = str_replace('}{', "},\n{", $report);
-            $report = "[\n" . $report . "\n]";
+    /**
+     * Returns the absolute file path to the XML file containing the test results.
+     *
+     * @param Task   $task
+     * @param Result $result
+     *
+     * @return string
+     */
+    private function getReportFilename(Task $task, Result $result)
+    {
+        return $result->getBuildDir($task) . '/report.xml';
+    }
 
-            $filesystem->dumpFile($filename, $report);
-
-            return $report;
-        } catch (IOException $e) {
-            return false;
-        }
+    /**
+     * Returns all failed and error results; the node value contains the error message that occurred.
+     *
+     * @param \SimpleXMLElement $report
+     *
+     * @return \SimpleXMLElement[]
+     */
+    private function fetchAllFailuresAndErrors(\SimpleXMLElement $report)
+    {
+        return $report->xpath('/testsuites/testsuite/testcase/failure|/testsuites/testsuite/testcase/error');
     }
 }

--- a/src/F500/CI/Task/Codeception/CodeceptionTask.php
+++ b/src/F500/CI/Task/Codeception/CodeceptionTask.php
@@ -61,7 +61,7 @@ class CodeceptionTask extends BaseTask
 
         $command = $this->createCommand($commandFactory);
         $command->addArg('run');
-        $command->addArg('--json');
+        $command->addArg('--xml');
         $command->addArg('--silent');
         $command->addArg('--no-exit');
 


### PR DESCRIPTION
The parallel processing of unit tests can only merge XML result files. Since
the Codeception tasks in FutureCI make use of JSON instead of XML I had to
change either the JSON to XML in the Codeception Parallel actions (which
would be time consuming) or change FutureCI to use XML as output instead
of JSON.

The latter proved trivial so in this commit we have replaced the JSON output
with XML and matched the tests to verify this.
