### PR TITLE
Use the suite name in the config if provided

### DIFF
--- a/src/F500/CI/Runner/Configurator.php
+++ b/src/F500/CI/Runner/Configurator.php
@@ -153,7 +153,9 @@ class Configurator
         $config = $driver->load($filename);
         $config = $this->parseConfig($config, $parameters);
 
-        $config['suite']['cn'] = $suiteCn;
+        $config['suite']['cn'] = isset($config['suite']['name'])
+            ? strtolower(str_replace(' ', '_', $config['suite']['name']))
+            : $suiteCn;
 
         if (empty($config['suite']['class'])) {
             $config['suite']['class'] = self::DEFAULT_SUITE_CLASS;


### PR DESCRIPTION
In this commit I have altered the algorith for retrieving the Build CN
(name used to make the build path with) to use the build.name variable
in the configuration if it exists.

If the name does not exist it will fallback to the current behaviour
and use the filename.

The Build CN is not a one-to-one match with the name; any uppercase letters
are converted to lowercase and spaces are converted to underscores to match
the existing format.
