### PR TITLE
Go back to build listing after viewing a build

### DIFF
--- a/app/assets/js/directives.js
+++ b/app/assets/js/directives.js
@@ -39,7 +39,7 @@ fciDirectives.directive('fciNavbar', ['$location',
                 var routeItem,
                     path = $location.path();
 
-                patternMap.foreach(function (item, pattern) {
+                jQuery.each(patternMap, function (pattern, item) {
                     pattern = new RegExp(pattern);
 
                     if (pattern.test(path)) {
@@ -52,6 +52,7 @@ fciDirectives.directive('fciNavbar', ['$location',
                     if (activeItem) {
                         activeItem.removeClass('active');
                     }
+
                     activeItem = routeItem;
                     activeItem.addClass('active');
                 }

--- a/app/assets/js/prototypes.js
+++ b/app/assets/js/prototypes.js
@@ -49,53 +49,6 @@
     };
 
     /**
-     * @returns {*}
-     */
-    Object.prototype.first = function () {
-        var first = undefined;
-
-        this.foreach(function (current) {
-            first = current;
-            return false;
-        });
-
-        return first;
-    };
-
-    /**
-     * @returns {*}
-     */
-    Object.prototype.last = function () {
-        var last = undefined;
-
-        this.foreach(function (current) {
-            last = current;
-        });
-
-        return last;
-    };
-
-    /**
-     * @param   {function} callback
-     * @returns {object}
-     */
-    Object.prototype.foreach = function (callback) {
-        var result,
-            i;
-
-        for (i in this) {
-            if (this.hasOwnProperty(i)) {
-                result = callback.call(this, this[i], i);
-                if (result === false) {
-                    break;
-                }
-            }
-        }
-
-        return this;
-    };
-
-    /**
      * @returns {number}
      */
     Date.prototype.getIsoWeek = function () {


### PR DESCRIPTION
During testing I discovered that it was not possible to return to the
home page and build listing after viewing a build's details.

After some research this was caused because the Object.prototype was
extended; something which jQuery does not accept.

Because the build details page was the first to use this feature it
was also the first one to show problematic behaviour.

To fix this I have removed all code regarding the extension of
Object.prototype and changed all parts of the code that makes use
of these extensions.
