### PR TITLE
Add a failure/success message to Slack

### DIFF
--- a/spec/F500/CI/Build/ResultSpec.php
+++ b/spec/F500/CI/Build/ResultSpec.php
@@ -237,7 +237,8 @@ class ResultSpec extends ObjectBehavior
                     "result_code": 0,
                     "output": "Some output..."
                 }
-            }
+            },
+            "message": ""
         }
     }
 }

--- a/spec/F500/CI/Event/Subscriber/SlackSubscriberSpec.php
+++ b/spec/F500/CI/Event/Subscriber/SlackSubscriberSpec.php
@@ -29,6 +29,8 @@ use Prophecy\Argument;
 class SlackSubscriberSpec extends ObjectBehavior
 {
 
+    const TASK_NAME = 'task_name';
+
     function let(
         BuildRunEvent $event,
         Build $build,
@@ -44,6 +46,7 @@ class SlackSubscriberSpec extends ObjectBehavior
 
         $event->getBuild()->willReturn($build);
 
+        $task->getName()->willReturn(self::TASK_NAME);
         $build->getCn()->willReturn('a1b2c3d4');
         $build->getSuiteName()->willReturn('Some Suite');
         $build->getTasks()->willReturn(array('some_task' => $task));
@@ -61,7 +64,7 @@ class SlackSubscriberSpec extends ObjectBehavior
         $ab->setText(Argument::type('string'))->willReturn($ab);
         $ab->setFallback(Argument::type('string'))->willReturn($ab);
         $ab->setColor(Argument::type('string'))->willReturn($ab);
-//        $ab->addField(Argument::type('string'), Argument::type('string'), Argument::type('bool'))->willReturn($ab);
+        $ab->addField(self::TASK_NAME, Argument::type('string'), Argument::type('bool'))->willReturn($ab);
         $ab->end()->willReturn($mb);
     }
 
@@ -89,8 +92,10 @@ class SlackSubscriberSpec extends ObjectBehavior
     ) {
         $event->getResult()->willReturn($result);
 
+        $message = "Reason why it passed";
         $result->getBuildStatus()->willReturn(Result::PASSED);
         $result->getTaskStatus(Argument::type('F500\CI\Task\Task'))->willReturn(Result::PASSED);
+        $result->getTaskMessage(Argument::type('F500\CI\Task\Task'))->willReturn($message);
         $result->getElapsedBuildTime()->willReturn(12345678);
 
         $this->onBuildFinished($event);
@@ -101,7 +106,7 @@ class SlackSubscriberSpec extends ObjectBehavior
 
         $ab->setFallback(Argument::containingString('Passed'))->shouldHaveBeenCalled();
         $ab->setColor('good')->shouldHaveBeenCalled();
-//        $ab->addField(Argument::type('string'), Argument::type('string'), false)->shouldHaveBeenCalled();
+        $ab->addField(self::TASK_NAME, $message, false)->shouldHaveBeenCalled();
     }
 
     function it_sends_a_slack_failed_message_on_build_failed(
@@ -113,8 +118,10 @@ class SlackSubscriberSpec extends ObjectBehavior
     ) {
         $event->getResult()->willReturn($result);
 
+        $message = "Reason why it failed";
         $result->getBuildStatus()->willReturn(Result::FAILED);
         $result->getTaskStatus(Argument::type('F500\CI\Task\Task'))->willReturn(Result::FAILED);
+        $result->getTaskMessage(Argument::type('F500\CI\Task\Task'))->willReturn($message);
         $result->getElapsedBuildTime()->willReturn(12345678);
 
         $this->onBuildFinished($event);
@@ -125,7 +132,7 @@ class SlackSubscriberSpec extends ObjectBehavior
 
         $ab->setFallback(Argument::containingString('Failed'))->shouldHaveBeenCalled();
         $ab->setColor('warning')->shouldHaveBeenCalled();
-//        $ab->addField(Argument::type('string'), Argument::type('string'), false)->shouldHaveBeenCalled();
+        $ab->addField(self::TASK_NAME, $message, false)->shouldHaveBeenCalled();
     }
 
     function it_sends_a_slack_borked_message_on_build_borked(
@@ -137,8 +144,10 @@ class SlackSubscriberSpec extends ObjectBehavior
     ) {
         $event->getResult()->willReturn($result);
 
+        $message = "Reason why it borked";
         $result->getBuildStatus()->willReturn(Result::BORKED);
         $result->getTaskStatus(Argument::type('F500\CI\Task\Task'))->willReturn(Result::BORKED);
+        $result->getTaskMessage(Argument::type('F500\CI\Task\Task'))->willReturn($message);
         $result->getElapsedBuildTime()->willReturn(12345678);
 
         $this->onBuildFinished($event);
@@ -149,6 +158,6 @@ class SlackSubscriberSpec extends ObjectBehavior
 
         $ab->setFallback(Argument::containingString('Borked'))->shouldHaveBeenCalled();
         $ab->setColor('danger')->shouldHaveBeenCalled();
-//        $ab->addField(Argument::type('string'), Argument::type('string'), false)->shouldHaveBeenCalled();
+        $ab->addField(self::TASK_NAME, $message, false)->shouldHaveBeenCalled();
     }
 }

--- a/spec/F500/CI/Task/Codeception/CodeceptionResultParserSpec.php
+++ b/spec/F500/CI/Task/Codeception/CodeceptionResultParserSpec.php
@@ -82,10 +82,10 @@ XML;
 
         $result->getBuildDir($task)->willReturn('/path/to/build');
         $result->getFilesystem()->willReturn($filesystem);
-        $result->markTaskAsFailed($task)->willReturn();
+        $result->markTaskAsFailed($task, Argument::type('string'))->willReturn();
 
         $this->parse($task, $result);
 
-        $result->markTaskAsFailed($task)->shouldHaveBeenCalled();
+        $result->markTaskAsFailed($task, Argument::type('string'))->shouldHaveBeenCalled();
     }
 }

--- a/src/F500/CI/Build/Result.php
+++ b/src/F500/CI/Build/Result.php
@@ -150,26 +150,32 @@ class Result
 
     /**
      * @param Task $task
+     * @param string $message
      */
-    public function markTaskAsPassed(Task $task)
+    public function markTaskAsPassed(Task $task, $message = '')
     {
         $this->statuses['tasks'][$task->getCn()] = self::PASSED;
+        $this->addAdditionalResult($task, 'message', $message);
     }
 
     /**
-     * @param Task $task
+     * @param Task   $task
+     * @param string $message
      */
-    public function markTaskAsFailed(Task $task)
+    public function markTaskAsFailed(Task $task, $message = '')
     {
         $this->statuses['tasks'][$task->getCn()] = self::FAILED;
+        $this->addAdditionalResult($task, 'message', $message);
     }
 
     /**
      * @param Task $task
+     * @param string $message
      */
-    public function markTaskAsBorked(Task $task)
+    public function markTaskAsBorked(Task $task, $message = '')
     {
         $this->statuses['tasks'][$task->getCn()] = self::BORKED;
+        $this->addAdditionalResult($task, 'message', $message);
     }
 
     /**
@@ -194,6 +200,20 @@ class Result
         }
 
         return $this->statuses['tasks'][$task->getCn()];
+    }
+
+    /**
+     * Returns the message that came with the build status for the given task.
+     *
+     * @param Task $task
+     *
+     * @return string
+     */
+    public function getTaskMessage(Task $task)
+    {
+        return isset($this->results[$task->getCn()]['message'])
+            ? $this->results[$task->getCn()]['message']
+            : '';
     }
 
     /**

--- a/src/F500/CI/Event/Subscriber/SlackSubscriber.php
+++ b/src/F500/CI/Event/Subscriber/SlackSubscriber.php
@@ -113,13 +113,12 @@ class SlackSubscriber implements EventSubscriberInterface
             ->setText($text)
             ->setColor($color);
 
-//        foreach ($build->getTasks() as $task) {
-//            $attachmentBuilder->addField(
-//                $task->getName(),
-//                $this->resultTextMap[$result->getTaskStatus($task)],
-//                false
-//            );
-//        }
+        foreach ($build->getTasks() as $task) {
+            $message = $result->getTaskMessage($task);
+            if ($message) {
+                $attachmentBuilder->addField($task->getName(), $message, false);
+            }
+        }
 
         $attachmentBuilder->end();
 

--- a/src/F500/CI/Task/Codeception/CodeceptionResultParser.php
+++ b/src/F500/CI/Task/Codeception/CodeceptionResultParser.php
@@ -33,8 +33,14 @@ final class CodeceptionResultParser extends BaseResultParser
     {
         $report = $this->loadReport($task, $result);
 
-        if (count($this->fetchAllFailuresAndErrors($report)) > 0) {
-            $result->markTaskAsFailed($task);
+        $failuresAndErrors = $this->fetchAllFailuresAndErrors($report);
+        if (count($failuresAndErrors) > 0) {
+            $messages = '';
+            foreach($failuresAndErrors as $message) {
+                $messages .= (string)$message . "\n";
+            }
+
+            $result->markTaskAsFailed($task, $messages);
         } else {
             $result->markTaskAsPassed($task);
         }


### PR DESCRIPTION
With this change I want to introduce a new 'message' section in the results
of a task execution. This message can contain a small custom piece of text
that describes why the build failed/borked/succeeded.
