### PR TITLE
Runs with a single skip_suite throw warning

### DIFF
--- a/src/F500/CI/Task/Codeception/CodeceptionTask.php
+++ b/src/F500/CI/Task/Codeception/CodeceptionTask.php
@@ -72,6 +72,10 @@ class CodeceptionTask extends BaseTask
         if (!empty($options['suite'])) {
             $specificSuite = $options['suite'];
         } elseif (!empty($options['skip_suites'])) {
+            if (!is_array($options['skip_suites'])) {
+                $options['skip_suites'] = array($options['skip_suites']);
+            }
+            
             foreach ($options['skip_suites'] as $suite) {
                 $command->addArg('--skip=' . $suite);
             }


### PR DESCRIPTION
When using the skip_suite configuration option you get an error
if you provide a string instead of an array. I have changed the
handling to support this use case by converting anything non-array
to an array there.
