### PR TITLE
Restrict attached messages to Slack result to three lines

### DIFF
--- a/src/F500/CI/Event/Subscriber/SlackSubscriber.php
+++ b/src/F500/CI/Event/Subscriber/SlackSubscriber.php
@@ -118,7 +118,10 @@ class SlackSubscriber implements EventSubscriberInterface
             $message = $result->getTaskMessage($task);
             if ($message) {
                 // limit number of lines to self::MAX_LINES_IN_MESSAGE and append an ellipsis
-                $message = implode("\n", array_slice(explode("\n", $message), 0, self::MAX_LINES_IN_MESSAGE)) . ' ...';
+                $message = implode(
+                    "\n",
+                    array_slice(explode("\n", $message), 0, self::MAX_LINES_IN_MESSAGE)
+                ) . " \n...";
 
                 $attachmentBuilder->addField($task->getName(), $message, false);
             }

--- a/src/F500/CI/Event/Subscriber/SlackSubscriber.php
+++ b/src/F500/CI/Event/Subscriber/SlackSubscriber.php
@@ -22,6 +22,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class SlackSubscriber implements EventSubscriberInterface
 {
+    const MAX_LINES_IN_MESSAGE = 3;
 
     /**
      * @var Phlack
@@ -116,6 +117,9 @@ class SlackSubscriber implements EventSubscriberInterface
         foreach ($build->getTasks() as $task) {
             $message = $result->getTaskMessage($task);
             if ($message) {
+                // limit number of lines to self::MAX_LINES_IN_MESSAGE and append an ellipsis
+                $message = implode("\n", array_slice(explode("\n", $message), 0, self::MAX_LINES_IN_MESSAGE)) . ' ...';
+
                 $attachmentBuilder->addField($task->getName(), $message, false);
             }
         }


### PR DESCRIPTION
Because test results may feature multiple lines of Stack trace and
you do not want to see this in your Slack channel I have limited
the number of returned line to three in the output.
