### PR TITLE
Bork build if the Codeception report is empty

### DIFF
--- a/spec/F500/CI/Task/Codeception/CodeceptionResultParserSpec.php
+++ b/spec/F500/CI/Task/Codeception/CodeceptionResultParserSpec.php
@@ -88,4 +88,18 @@ XML;
 
         $result->markTaskAsFailed($task, Argument::type('string'))->shouldHaveBeenCalled();
     }
+
+    function it_should_fail_on_empty_xml(Task $task, Result $result, Filesystem $filesystem)
+    {
+        $filesystem->exists(Argument::type('string'))->willReturn(true);
+        $filesystem->readFile(Argument::type('string'))->willReturn("");
+
+        $result->getBuildDir($task)->willReturn('/path/to/build');
+        $result->getFilesystem()->willReturn($filesystem);
+        $result->markTaskAsBorked($task, Argument::type('string'))->willReturn();
+
+        $this->parse($task, $result);
+
+        $result->markTaskAsBorked($task, Argument::type('string'))->shouldHaveBeenCalled();
+    }
 }

--- a/src/F500/CI/Runner/TaskRunner.php
+++ b/src/F500/CI/Runner/TaskRunner.php
@@ -86,8 +86,14 @@ class TaskRunner
             }
         }
 
-        foreach ($task->getResultParsers() as $parser) {
-            $parser->parse($task, $result);
+        try {
+            foreach ($task->getResultParsers() as $parser) {
+                $parser->parse($task, $result);
+            }
+        } catch (\Exception $e) {
+            $result->markTaskAsBorked($task, $e->getMessage());
+
+            return false;
         }
 
         return true;


### PR DESCRIPTION
It can happen that all builds fail and the codeception report.xml
file does not contain valid XML (including an empty file). If this
happens then the build currently passes because the result object is
not marked as borked or failed.

With these changes I have added two mechanisms:
1. if the XML file is empty or otherwise contains invalid XML then
   the Result is marked as borked
2. If any parser throws an exception than the TaskRunner will also
   mark the build as borked.
