### PR TITLE
[WIP] Add commit information to output

### DIFF
--- a/spec/F500/CI/Build/StandardBuildSpec.php
+++ b/spec/F500/CI/Build/StandardBuildSpec.php
@@ -9,6 +9,7 @@ namespace spec\F500\CI\Build;
 
 use F500\CI\Suite\Suite;
 use F500\CI\Task\Task;
+use F500\CI\Vcs\Commit;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -87,6 +88,15 @@ EOT;
     function it_has_tasks(Task $task)
     {
         $this->getTasks()->shouldReturn(array('some_task' => $task));
+    }
+
+    function it_can_optionally_have_a_commit_with_which_it_was_started(Commit $commit)
+    {
+        $this->getCommit()->shouldReturn(null);
+
+        $this->initiatedBy($commit)->shouldReturn($this);
+
+        $this->getCommit()->shouldReturn($commit);
     }
 
     function it_turns_itself_into_json()

--- a/spec/F500/CI/Build/StandardBuildSpec.php
+++ b/spec/F500/CI/Build/StandardBuildSpec.php
@@ -22,6 +22,7 @@ use Prophecy\Argument;
  */
 class StandardBuildSpec extends ObjectBehavior
 {
+    const PROJECT_FOLDER = '/our/project/folder';
 
     protected $suiteJson = <<< EOT
 {
@@ -39,6 +40,7 @@ EOT;
     function let(Suite $suite, Task $task)
     {
         $suite->getCn()->willReturn('some_suite');
+        $suite->getConfig()->willReturn(array('root_dir' => self::PROJECT_FOLDER));
         $suite->getName()->willReturn('Some Suite');
         $suite->getTasks()->willReturn(array('some_task' => $task));
         $suite->toJson()->willReturn($this->suiteJson);
@@ -76,6 +78,11 @@ EOT;
     function it_has_a_build_dir()
     {
         $this->getBuildDir()->shouldMatch('|^/path/to/builds/some_suite/[a-z0-9]+$|');
+    }
+
+    function it_has_a_project_dir()
+    {
+        $this->getProjectDir()->shouldReturn(self::PROJECT_FOLDER);
     }
 
     function it_has_a_build_dir_for_a_task(Task $task)

--- a/spec/F500/CI/Event/Subscriber/GitSubscriberSpec.php
+++ b/spec/F500/CI/Event/Subscriber/GitSubscriberSpec.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the Future CI package.
+ * Future CI is licensed under MIT (https://github.com/f500/future-ci/blob/master/LICENSE).
+ */
+
+namespace spec\F500\CI\Event\Subscriber;
+
+use F500\CI\Build\Build;
+use F500\CI\Event\BuildRunEvent;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * Class TimerSubscriberSpec
+ *
+ * @copyright 2014 Future500 B.V.
+ * @license   https://github.com/f500/future-ci/blob/master/LICENSE MIT
+ * @package   spec\F500\CI\Event\Subscriber
+ */
+class GitSubscriberSpec extends ObjectBehavior
+{
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('F500\CI\Event\Subscriber\GitSubscriber');
+        $this->shouldImplement('Symfony\Component\EventDispatcher\EventSubscriberInterface');
+    }
+
+    function it_registers_the_commit_with_the_build(BuildRunEvent $event, Build $build)
+    {
+        $event->getBuild()->willReturn($build);
+        $build->initiatedBy(Argument::type('F500\CI\Vcs\Commit'))->willReturn(null);
+
+        // Minor evil: because the 'load' method is a static factory method we cannot mock the actual
+        // creation of the Commit object; this means that we are going to assume that the current folder
+        // is under Version Control using git.
+        //
+        // It might be better to create a Commit Factory that uses a strategy pattern
+        $build->getProjectDir()->willReturn(__DIR__);
+
+        $this->onBuildStarted($event);
+
+        $build->getProjectDir()->shouldHaveBeenCalled();
+        $build->initiatedBy(Argument::type('F500\CI\Vcs\Commit'))->shouldHaveBeenCalled();
+    }
+}

--- a/spec/F500/CI/Event/Subscriber/SlackSubscriberSpec.php
+++ b/spec/F500/CI/Event/Subscriber/SlackSubscriberSpec.php
@@ -50,6 +50,7 @@ class SlackSubscriberSpec extends ObjectBehavior
         $build->getCn()->willReturn('a1b2c3d4');
         $build->getSuiteName()->willReturn('Some Suite');
         $build->getTasks()->willReturn(array('some_task' => $task));
+        $build->getCommit()->willReturn(null);
 
 //        $task->getCn()->willReturn('some_task');
 //        $task->getName()->willReturn('Some Task');

--- a/spec/F500/CI/Runner/ConfiguratorSpec.php
+++ b/spec/F500/CI/Runner/ConfiguratorSpec.php
@@ -78,18 +78,7 @@ class ConfiguratorSpec extends ObjectBehavior
     function it_loads_a_json_config_file()
     {
         $filename = __DIR__ . '/../../../data/suites/some_suite.json';
-        $config   = array(
-            'suite' => array(
-                'name'  => 'Some Suite',
-                'path'  => '/path/to/root/some/path',
-                'foo'   => array('bar', 'baz'),
-                'cn'    => 'some_suite',
-                'class' => 'F500\CI\Suite\StandardSuite'
-            ),
-            'build' => array(
-                'class' => 'F500\CI\Build\StandardBuild'
-            )
-        );
+        $config = $this->givenAnExpectedConfiguration();
 
         $this->loadConfig($filename)->shouldReturn($config);
     }
@@ -97,18 +86,7 @@ class ConfiguratorSpec extends ObjectBehavior
     function it_loads_a_php_config_file()
     {
         $filename = __DIR__ . '/../../../data/suites/some_suite.php';
-        $config   = array(
-            'suite' => array(
-                'name'  => 'Some Suite',
-                'path'  => '/path/to/root/some/path',
-                'foo'   => array('bar', 'baz'),
-                'cn'    => 'some_suite',
-                'class' => 'F500\CI\Suite\StandardSuite'
-            ),
-            'build' => array(
-                'class' => 'F500\CI\Build\StandardBuild'
-            )
-        );
+        $config = $this->givenAnExpectedConfiguration();
 
         $this->loadConfig($filename)->shouldReturn($config);
     }
@@ -116,18 +94,7 @@ class ConfiguratorSpec extends ObjectBehavior
     function it_loads_a_toml_config_file()
     {
         $filename = __DIR__ . '/../../../data/suites/some_suite.toml';
-        $config   = array(
-            'suite' => array(
-                'name'  => 'Some Suite',
-                'path'  => '/path/to/root/some/path',
-                'foo'   => array('bar', 'baz'),
-                'cn'    => 'some_suite',
-                'class' => 'F500\CI\Suite\StandardSuite'
-            ),
-            'build' => array(
-                'class' => 'F500\CI\Build\StandardBuild'
-            )
-        );
+        $config = $this->givenAnExpectedConfiguration();
 
         $this->loadConfig($filename)->shouldReturn($config);
     }
@@ -135,18 +102,7 @@ class ConfiguratorSpec extends ObjectBehavior
     function it_loads_a_yaml_config_file()
     {
         $filename = __DIR__ . '/../../../data/suites/some_suite.yml';
-        $config   = array(
-            'suite' => array(
-                'name'  => 'Some Suite',
-                'path'  => '/path/to/root/some/path',
-                'foo'   => array('bar', 'baz'),
-                'cn'    => 'some_suite',
-                'class' => 'F500\CI\Suite\StandardSuite'
-            ),
-            'build' => array(
-                'class' => 'F500\CI\Build\StandardBuild'
-            )
-        );
+        $config = $this->givenAnExpectedConfiguration();
 
         $this->loadConfig($filename)->shouldReturn($config);
     }
@@ -154,18 +110,7 @@ class ConfiguratorSpec extends ObjectBehavior
     function it_loads_a_config_file_with_relative_path()
     {
         $filename = 'some_suite.yml';
-        $config   = array(
-            'suite' => array(
-                'name'  => 'Some Suite',
-                'path'  => '/path/to/root/some/path',
-                'foo'   => array('bar', 'baz'),
-                'cn'    => 'some_suite',
-                'class' => 'F500\CI\Suite\StandardSuite'
-            ),
-            'build' => array(
-                'class' => 'F500\CI\Build\StandardBuild'
-            )
-        );
+        $config = $this->givenAnExpectedConfiguration();
 
         $this->loadConfig($filename)->shouldReturn($config);
     }
@@ -174,18 +119,8 @@ class ConfiguratorSpec extends ObjectBehavior
     {
         $filename = __DIR__ . '/../../../data/suites/some_suite';
         $format   = 'yml';
-        $config   = array(
-            'suite' => array(
-                'name'  => 'Some Suite',
-                'path'  => '/path/to/root/some/path',
-                'foo'   => array('bar', 'baz'),
-                'cn'    => 'some_suite',
-                'class' => 'F500\CI\Suite\StandardSuite'
-            ),
-            'build' => array(
-                'class' => 'F500\CI\Build\StandardBuild'
-            )
-        );
+        $config = $this->givenAnExpectedConfiguration();
+;
 
         $this->loadConfig($filename, $format)->shouldReturn($config);
     }
@@ -199,6 +134,7 @@ class ConfiguratorSpec extends ObjectBehavior
                 'name'  => 'Some Suite',
                 'path'  => '/path/to/root/some/path',
                 'foo'   => 'bar',
+                'root_dir' => '/path/to/root',
                 'cn'    => 'some_suite',
                 'class' => 'F500\CI\Suite\StandardSuite'
             ),
@@ -693,5 +629,26 @@ class ConfiguratorSpec extends ObjectBehavior
     {
         $this->createBuild('F500\CI\Build\StandardBuild', $suite)
             ->shouldReturnAnInstanceOf('F500\CI\Build\Build');
+    }
+
+    /**
+     * @return array
+     */
+    protected function givenAnExpectedConfiguration()
+    {
+        $config = array(
+            'suite' => array(
+                'name' => 'Some Suite',
+                'path' => '/path/to/root/some/path',
+                'foo' => array('bar', 'baz'),
+                'root_dir' => '/path/to/root',
+                'cn' => 'some_suite',
+                'class' => 'F500\CI\Suite\StandardSuite'
+            ),
+            'build' => array(
+                'class' => 'F500\CI\Build\StandardBuild'
+            )
+        );
+        return $config;
     }
 }

--- a/spec/F500/CI/Suite/StandardSuiteSpec.php
+++ b/spec/F500/CI/Suite/StandardSuiteSpec.php
@@ -58,6 +58,17 @@ class StandardSuiteSpec extends ObjectBehavior
         $this->getName()->shouldReturn('Some Suite');
     }
 
+    function it_has_a_configuration()
+    {
+        $this->getConfig()->shouldReturn(
+            array(
+                'name'  => 'Some Suite',
+                'cn'    => 'some_suite',
+                'class' => 'F500\CI\Suite\StandardSuite'
+            )
+        );
+    }
+
     function it_can_add_a_task_to_itself(Task $task)
     {
         $this->addTask('some_task', $task);

--- a/spec/F500/CI/Vcs/CommitHashSpec.php
+++ b/spec/F500/CI/Vcs/CommitHashSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of the Future CI package.
+ * Future CI is licensed under MIT (https://github.com/f500/future-ci/blob/master/LICENSE).
+ */
+
+namespace spec\F500\CI\Vcs;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * Class CommitHashSpec
+ *
+ * @copyright 2014 Future500 B.V.
+ * @license   https://github.com/f500/future-ci/blob/master/LICENSE MIT
+ * @package   spec\F500\CI\Suite
+ */
+class CommitHashSpec extends ObjectBehavior
+{
+
+    function let()
+    {
+        /** @noinspection PhpParamsInspection */
+        $this->beConstructedWith(sha1('some_commit'));
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('F500\CI\Vcs\CommitHash');
+        $this->shouldImplement('F500\CI\Vcs\CommitId');
+    }
+
+    function it_has_a_value()
+    {
+        $this->__toString()->shouldReturn(sha1('some_commit'));
+    }
+}

--- a/spec/F500/CI/Vcs/GitCommitSpec.php
+++ b/spec/F500/CI/Vcs/GitCommitSpec.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of the Future CI package.
+ * Future CI is licensed under MIT (https://github.com/f500/future-ci/blob/master/LICENSE).
+ */
+
+namespace spec\F500\CI\Vcs;
+
+use F500\CI\Vcs\CommitHash;
+use F500\CI\Vcs\GitCommit;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * Class CommitHashSpec
+ *
+ * @copyright 2014 Future500 B.V.
+ * @license   https://github.com/f500/future-ci/blob/master/LICENSE MIT
+ * @package   spec\F500\CI\Suite
+ */
+class GitCommitSpec extends ObjectBehavior
+{
+    const DESCRIPTION = 'description';
+
+    const AUTHOR = 'author';
+
+    private $date;
+
+    private $id;
+
+    function let(CommitHash $id)
+    {
+        $this->id   = $id;
+        $this->date = new \DateTime();
+
+        $this->beConstructedWith($this->id, $this->date, self::AUTHOR, self::DESCRIPTION);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('F500\CI\Vcs\GitCommit');
+        $this->shouldImplement('F500\CI\Vcs\Commit');
+    }
+
+    function it_has_an_id()
+    {
+        $this->getId()->shouldReturn($this->id);
+    }
+
+    function it_has_a_date()
+    {
+        $this->getDate()->shouldReturn($this->date);
+    }
+
+    function it_has_an_author()
+    {
+        $this->getAuthor()->shouldReturn(self::AUTHOR);
+    }
+
+    function it_has_a_description()
+    {
+        $this->getDescription()->shouldReturn(self::DESCRIPTION);
+    }
+}

--- a/src/F500/CI/Build/Build.php
+++ b/src/F500/CI/Build/Build.php
@@ -36,8 +36,20 @@ interface Build
      */
     public function getDate();
 
-    public function setCommit(Commit $commit);
+    /**
+     * Registers information on the commit that initiated this build.
+     *
+     * @param Commit $commit
+     *
+     * @return $this
+     */
+    public function initiatedBy(Commit $commit);
 
+    /**
+     * Returns the commit that initiated this build or null if this is unknown or not applicable.
+     *
+     * @return Commit|null
+     */
     public function getCommit();
 
     /**

--- a/src/F500/CI/Build/Build.php
+++ b/src/F500/CI/Build/Build.php
@@ -8,6 +8,7 @@
 namespace F500\CI\Build;
 
 use F500\CI\Suite\Suite;
+use F500\CI\Vcs\Commit;
 
 /**
  * Interface Build
@@ -34,6 +35,10 @@ interface Build
      * @return \DateTimeImmutable
      */
     public function getDate();
+
+    public function setCommit(Commit $commit);
+
+    public function getCommit();
 
     /**
      * @return string

--- a/src/F500/CI/Build/Build.php
+++ b/src/F500/CI/Build/Build.php
@@ -63,6 +63,13 @@ interface Build
     public function getSuiteName();
 
     /**
+     * Returns the name of the directory where the sources for this build are located.
+     *
+     * @return string
+     */
+    public function getProjectDir();
+
+    /**
      * @return string
      */
     public function getBuildDir();

--- a/src/F500/CI/Build/StandardBuild.php
+++ b/src/F500/CI/Build/StandardBuild.php
@@ -38,7 +38,7 @@ class StandardBuild implements Build
     protected $suite;
 
     /**
-     * @var Commit
+     * @var Commit|null The commit that initiated this build or null if this is unknown or not applicable.
      */
     private $commit;
 
@@ -106,16 +106,29 @@ class StandardBuild implements Build
         return $buildDir;
     }
 
-    public function setCommit(Commit $commit)
+    /**
+     * Registers information on the commit that initiated this build.
+     *
+     * @param Commit $commit
+     *
+     * @return $this;
+     */
+    public function initiatedBy(Commit $commit)
     {
         $this->commit = $commit;
+
+        return $this;
     }
 
+    /**
+     * Returns the commit that initiated this build or null if this is unknown or not applicable.
+     *
+     * @return Commit|null
+     */
     public function getCommit()
     {
         return $this->commit;
     }
-
 
     /**
      * @return \F500\CI\Task\Task[]

--- a/src/F500/CI/Build/StandardBuild.php
+++ b/src/F500/CI/Build/StandardBuild.php
@@ -77,10 +77,16 @@ class StandardBuild implements Build
         return $this->suite->getCn();
     }
 
-    /** @return StandardSuite */
-    public function getSuite()
+    /**
+     * Returns the name of the directory where the sources for this build are located.
+     *
+     * @return string
+     */
+    public function getProjectDir()
     {
-        return $this->suite;
+        $config = $this->suite->getConfig();
+
+        return isset($config['root_dir']) ? $config['root_dir'] : null;
     }
 
     /**

--- a/src/F500/CI/Build/StandardBuild.php
+++ b/src/F500/CI/Build/StandardBuild.php
@@ -7,8 +7,10 @@
 
 namespace F500\CI\Build;
 
+use F500\CI\Suite\StandardSuite;
 use F500\CI\Suite\Suite;
 use F500\CI\Task\Task;
+use F500\CI\Vcs\Commit;
 
 /**
  * Class StandardBuild
@@ -34,6 +36,11 @@ class StandardBuild implements Build
      * @var Suite
      */
     protected $suite;
+
+    /**
+     * @var Commit
+     */
+    private $commit;
 
     /**
      * @param Suite  $suite
@@ -70,6 +77,12 @@ class StandardBuild implements Build
         return $this->suite->getCn();
     }
 
+    /** @return StandardSuite */
+    public function getSuite()
+    {
+        return $this->suite;
+    }
+
     /**
      * @return string
      */
@@ -92,6 +105,17 @@ class StandardBuild implements Build
 
         return $buildDir;
     }
+
+    public function setCommit(Commit $commit)
+    {
+        $this->commit = $commit;
+    }
+
+    public function getCommit()
+    {
+        return $this->commit;
+    }
+
 
     /**
      * @return \F500\CI\Task\Task[]

--- a/src/F500/CI/Console/Command/RunCommand.php
+++ b/src/F500/CI/Console/Command/RunCommand.php
@@ -9,6 +9,7 @@ namespace F500\CI\Console\Command;
 
 use F500\CI\Console\Helper\RunHelper;
 use F500\CI\Event\Subscriber\ConsoleOutputSubscriber;
+use F500\CI\Event\Subscriber\GitSubscriber;
 use F500\CI\Event\Subscriber\SlackSubscriber;
 use F500\CI\Event\Subscriber\TimerSubscriber;
 use Symfony\Component\Console\Input\InputArgument;
@@ -51,6 +52,7 @@ class RunCommand extends Command
         $dispatcher = $this->getService('dispatcher');
         $phlack     = $this->getService('phlack');
 
+        $dispatcher->addSubscriber(new GitSubscriber());
         $dispatcher->addSubscriber(new SlackSubscriber($phlack));
         $dispatcher->addSubscriber(new ConsoleOutputSubscriber($output));
         $dispatcher->addSubscriber(new TimerSubscriber());

--- a/src/F500/CI/Event/Subscriber/ConsoleOutputSubscriber.php
+++ b/src/F500/CI/Event/Subscriber/ConsoleOutputSubscriber.php
@@ -110,6 +110,13 @@ class ConsoleOutputSubscriber implements EventSubscriberInterface
                 $build->getSuiteName()
             )
         );
+
+        $commit = $build->getCommit();
+        if ($commit) {
+            $this->output->writeln(
+                sprintf('Against commit [<fg=yellow>%s</fg=yellow>]', $commit->getId())
+            );
+        }
     }
 
     /**

--- a/src/F500/CI/Event/Subscriber/GitSubscriber.php
+++ b/src/F500/CI/Event/Subscriber/GitSubscriber.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the Future CI package.
+ * Future CI is licensed under MIT (https://github.com/f500/future-ci/blob/master/LICENSE).
+ */
+
+namespace F500\CI\Event\Subscriber;
+
+use F500\CI\Event\BuildRunEvent;
+use F500\CI\Event\Events;
+use F500\CI\Vcs\GitCommit;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class TimerSubscriber
+ *
+ * @copyright 2014 Future500 B.V.
+ * @license   https://github.com/f500/future-ci/blob/master/LICENSE MIT
+ * @package   F500\CI\Event\Subscriber
+ */
+class GitSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(Events::BuildStarted => array(array('onBuildStarted', 10)));
+    }
+
+    /**
+     * @param BuildRunEvent $event
+     */
+    public function onBuildStarted(BuildRunEvent $event)
+    {
+        $config = $event->getBuild()->getSuite()->getConfig();
+        $rootDir = isset($config['root_dir']) ? $config['root_dir'] : null;
+
+        $commit = GitCommit::load($rootDir);
+        $event->getBuild()->setCommit($commit);
+    }
+}

--- a/src/F500/CI/Event/Subscriber/GitSubscriber.php
+++ b/src/F500/CI/Event/Subscriber/GitSubscriber.php
@@ -30,12 +30,18 @@ class GitSubscriber implements EventSubscriberInterface
     }
 
     /**
+     * Registers the commit information of the current project directory with the build.
+     *
      * @param BuildRunEvent $event
+     *
+     * @return void
      */
     public function onBuildStarted(BuildRunEvent $event)
     {
-
-        $commit = GitCommit::load($event->getBuild()->getProjectDir());
-        $event->getBuild()->initiatedBy($commit);
+        $projectDirectory = $event->getBuild()->getProjectDir();
+        $commit = GitCommit::load($projectDirectory);
+        if ($commit) {
+            $event->getBuild()->initiatedBy($commit);
+        }
     }
 }

--- a/src/F500/CI/Event/Subscriber/GitSubscriber.php
+++ b/src/F500/CI/Event/Subscriber/GitSubscriber.php
@@ -38,6 +38,6 @@ class GitSubscriber implements EventSubscriberInterface
         $rootDir = isset($config['root_dir']) ? $config['root_dir'] : null;
 
         $commit = GitCommit::load($rootDir);
-        $event->getBuild()->setCommit($commit);
+        $event->getBuild()->initiatedBy($commit);
     }
 }

--- a/src/F500/CI/Event/Subscriber/GitSubscriber.php
+++ b/src/F500/CI/Event/Subscriber/GitSubscriber.php
@@ -34,10 +34,8 @@ class GitSubscriber implements EventSubscriberInterface
      */
     public function onBuildStarted(BuildRunEvent $event)
     {
-        $config = $event->getBuild()->getSuite()->getConfig();
-        $rootDir = isset($config['root_dir']) ? $config['root_dir'] : null;
 
-        $commit = GitCommit::load($rootDir);
+        $commit = GitCommit::load($event->getBuild()->getProjectDir());
         $event->getBuild()->initiatedBy($commit);
     }
 }

--- a/src/F500/CI/Event/Subscriber/SlackSubscriber.php
+++ b/src/F500/CI/Event/Subscriber/SlackSubscriber.php
@@ -79,9 +79,14 @@ class SlackSubscriber implements EventSubscriberInterface
 
         $messageBuilder = $this->phlack->getMessageBuilder();
 
-        $messageBuilder->setText(
-            sprintf('Build [%s] (%s) started.', $build->getCn(), $build->getSuiteName())
-        );
+        $message = sprintf('Build [%s] (%s) started.', $build->getCn(), $build->getSuiteName());
+
+        $commit = $build->getCommit();
+        if ($commit) {
+            $message .= sprintf("\nAgainst commit [%s]", $commit->getId());
+        }
+
+        $messageBuilder->setText($message);
 
         $response = $this->phlack->send($messageBuilder->create());
     }

--- a/src/F500/CI/Runner/Configurator.php
+++ b/src/F500/CI/Runner/Configurator.php
@@ -362,6 +362,7 @@ class Configurator
             }
         );
 
+        $config['suite']['root_dir'] = $parameters['root_dir'];
         unset($config['parameters']);
 
         return $config;

--- a/src/F500/CI/Suite/StandardSuite.php
+++ b/src/F500/CI/Suite/StandardSuite.php
@@ -139,6 +139,11 @@ class StandardSuite implements Suite
         return $this->wrappers[$cn];
     }
 
+    /**
+     * Returns the suite's specific configuration.
+     *
+     * @return string[]
+     */
     public function getConfig()
     {
         return $this->config['suite'];

--- a/src/F500/CI/Suite/StandardSuite.php
+++ b/src/F500/CI/Suite/StandardSuite.php
@@ -139,6 +139,11 @@ class StandardSuite implements Suite
         return $this->wrappers[$cn];
     }
 
+    public function getConfig()
+    {
+        return $this->config['suite'];
+    }
+
     /**
      * @return string
      */

--- a/src/F500/CI/Suite/Suite.php
+++ b/src/F500/CI/Suite/Suite.php
@@ -70,6 +70,8 @@ interface Suite
      */
     public function getWrapper($cn);
 
+    public function getConfig();
+
     /**
      * @return string
      */

--- a/src/F500/CI/Suite/Suite.php
+++ b/src/F500/CI/Suite/Suite.php
@@ -70,6 +70,11 @@ interface Suite
      */
     public function getWrapper($cn);
 
+    /**
+     * Returns the suite's specific configuration.
+     *
+     * @return string[]
+     */
     public function getConfig();
 
     /**

--- a/src/F500/CI/Vcs/Commit.php
+++ b/src/F500/CI/Vcs/Commit.php
@@ -1,22 +1,46 @@
 <?php
+
 /**
- * Created by PhpStorm.
- * User: mvriel
- * Date: 30/03/15
- * Time: 13:59
+ * This file is part of the Future CI package.
+ * Future CI is licensed under MIT (https://github.com/f500/future-ci/blob/master/LICENSE).
  */
 
 namespace F500\CI\Vcs;
 
-
+/**
+ * Interface Commit
+ *
+ * @copyright 2015 Future500 B.V.
+ * @license   https://github.com/f500/future-ci/blob/master/LICENSE MIT
+ * @package   F500\CI\Vcs
+ */
 interface Commit
 {
-    /** @return CommitId */
+    /**
+     * Returns the identifier for this commit.
+     *
+     * @return CommitId
+     */
     public function getId();
 
-    /** @return string */
-    public function getDescription();
-
-    /** @return \DateTime */
+    /**
+     * Returns the date and time when this commit was made.
+     *
+     * @return \DateTime
+     */
     public function getDate();
+
+    /**
+     * Returns the author information for this VCS.
+     *
+     * @return string
+     */
+    public function getAuthor();
+
+    /**
+     * Returns the commit message for this commit.
+     *
+     * @return string
+     */
+    public function getDescription();
 }

--- a/src/F500/CI/Vcs/Commit.php
+++ b/src/F500/CI/Vcs/Commit.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mvriel
+ * Date: 30/03/15
+ * Time: 13:59
+ */
+
+namespace F500\CI\Vcs;
+
+
+interface Commit
+{
+    /** @return CommitId */
+    public function getId();
+
+    /** @return string */
+    public function getDescription();
+
+    /** @return \DateTime */
+    public function getDate();
+}

--- a/src/F500/CI/Vcs/CommitHash.php
+++ b/src/F500/CI/Vcs/CommitHash.php
@@ -1,26 +1,43 @@
 <?php
+
 /**
- * Created by PhpStorm.
- * User: mvriel
- * Date: 30/03/15
- * Time: 14:05
+ * This file is part of the Future CI package.
+ * Future CI is licensed under MIT (https://github.com/f500/future-ci/blob/master/LICENSE).
  */
 
 namespace F500\CI\Vcs;
 
-
+/**
+ * Class CommitHash
+ *
+ * @copyright 2015 Future500 B.V.
+ * @license   https://github.com/f500/future-ci/blob/master/LICENSE MIT
+ * @package   F500\CI\Vcs
+ */
 class CommitHash implements CommitId
 {
+    /**
+     * @var string the sha1 hash that identifies a commit.
+     */
     private $value;
 
+    /**
+     * Registers the VCS specific commit id with this value object.
+     *
+     * @param string $value
+     */
     public function __construct($value)
     {
         $this->value = $value;
     }
 
+    /**
+     * Returns the identity of this value object as a string.
+     *
+     * @return string
+     */
     public function __toString()
     {
         return $this->value;
     }
-
 }

--- a/src/F500/CI/Vcs/CommitHash.php
+++ b/src/F500/CI/Vcs/CommitHash.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mvriel
+ * Date: 30/03/15
+ * Time: 14:05
+ */
+
+namespace F500\CI\Vcs;
+
+
+class CommitHash implements CommitId
+{
+    private $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString()
+    {
+        return $this->value;
+    }
+
+}

--- a/src/F500/CI/Vcs/CommitId.php
+++ b/src/F500/CI/Vcs/CommitId.php
@@ -1,17 +1,32 @@
 <?php
+
 /**
- * Created by PhpStorm.
- * User: mvriel
- * Date: 30/03/15
- * Time: 14:04
+ * This file is part of the Future CI package.
+ * Future CI is licensed under MIT (https://github.com/f500/future-ci/blob/master/LICENSE).
  */
 
 namespace F500\CI\Vcs;
 
-
+/**
+ * Interface CommitId
+ *
+ * @copyright 2015 Future500 B.V.
+ * @license   https://github.com/f500/future-ci/blob/master/LICENSE MIT
+ * @package   F500\CI\Vcs
+ */
 interface CommitId
 {
+    /**
+     * Registers the VCS specific commit id with this value object.
+     *
+     * @param string $value
+     */
     public function __construct($value);
 
+    /**
+     * Returns the identity of this value object as a string.
+     *
+     * @return string
+     */
     public function __toString();
 }

--- a/src/F500/CI/Vcs/CommitId.php
+++ b/src/F500/CI/Vcs/CommitId.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mvriel
+ * Date: 30/03/15
+ * Time: 14:04
+ */
+
+namespace F500\CI\Vcs;
+
+
+interface CommitId
+{
+    public function __construct($value);
+
+    public function __toString();
+}

--- a/src/F500/CI/Vcs/GitCommit.php
+++ b/src/F500/CI/Vcs/GitCommit.php
@@ -54,6 +54,13 @@ class GitCommit implements Commit
         $this->description = $description;
     }
 
+    /**
+     * Finds the latest commit in the given path and returns it.
+     *
+     * @param string $location
+     *
+     * @return static
+     */
     public static function load($location)
     {
         $process = new Process(

--- a/src/F500/CI/Vcs/GitCommit.php
+++ b/src/F500/CI/Vcs/GitCommit.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace F500\CI\Vcs;
+
+use Symfony\Component\Process\Process;
+
+class GitCommit implements Commit
+{
+    /** @var CommitHash $id */
+    private $id;
+
+    /** @var \DateTime */
+    private $date;
+
+    /** @var string */
+    private $description;
+
+    public function __construct(CommitHash $id, \DateTime $date, $description)
+    {
+        $this->id = $id;
+        $this->date = $date;
+        $this->description = $description;
+    }
+
+    public static function load($location)
+    {
+        $process = new Process(
+            'git log --no-merges --date-order --reverse --format=medium -1 --date=iso-strict'
+        );
+        $process->setWorkingDirectory($location);
+        $process->run();
+        if (! $process->isSuccessful()) {
+            throw new \RuntimeException(
+                "Unable to load commit information for the git commit at location '$location'. Either the 'git' "
+                . "executable is not in the PATH or the provided location is not a git repository."
+            );
+        }
+
+        $output = $process->getOutput();
+        $id          = null;
+        $description = "";
+        $author      = null;
+        $date        = null;
+
+        foreach(explode("\n", $output) as $line) {
+            if ($id === null) {
+                $id = new CommitHash(substr($line, 7));
+                continue;
+            }
+
+            if ($author === null) {
+                $author = substr($line, 8);
+                continue;
+            }
+
+            if ($date === null) {
+                $date = new \DateTime(substr($line, 8));
+                continue;
+            }
+
+            $description .= substr($line, 4) . "\n";
+        }
+
+        return new static($id, $date, $description);
+    }
+
+    /** @return CommitId */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /** @return \DateTime */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    public function getDescription()
+    {
+        return $this->id;
+    }
+
+
+}


### PR DESCRIPTION
Before this commit FutureCI was not aware of any commit information
during the build.

With this commit I have added a Git Subscriber to the Run Command
that retrieves the commit information from the root folder in the
configuration and sets a Commit entity object on the current Build.

With this information any other subscriber, such as the Slack and
Console subscriber are able to read and display additional information
about the commit that initiated this build.

The following steps still need to be done:
- [x] Add and adjust spec files
- [x] Document the added elements
