### PR TITLE
Add individual build information

### DIFF
--- a/spec/F500/CI/Build/BuildFactorySpec.php
+++ b/spec/F500/CI/Build/BuildFactorySpec.php
@@ -28,7 +28,7 @@ class BuildFactorySpec extends ObjectBehavior
 
     function it_creates_a_build(Suite $suite)
     {
-        $build = $this->createBuild('F500\CI\Build\StandardBuild', $suite, '/path/to/builds');
+        $build = $this->createBuild('F500\CI\Build\StandardBuild', $suite, '/path/to/builds', []);
 
         $build->shouldHaveType('F500\CI\Build\StandardBuild');
         $build->shouldImplement('F500\CI\Build\Build');
@@ -38,7 +38,7 @@ class BuildFactorySpec extends ObjectBehavior
     {
         $this->shouldThrow('InvalidArgumentException')->during(
             'createBuild',
-            array('NonExistent\Build', $suite, '/path/to/builds')
+            array('NonExistent\Build', $suite, '/path/to/builds', [])
         );
     }
 
@@ -46,7 +46,7 @@ class BuildFactorySpec extends ObjectBehavior
     {
         $this->shouldThrow('InvalidArgumentException')->during(
             'createBuild',
-            array('StdClass', $suite, '/path/to/builds')
+            array('StdClass', $suite, '/path/to/builds', [])
         );
     }
 }

--- a/spec/F500/CI/Build/BuildInfoSpec.php
+++ b/spec/F500/CI/Build/BuildInfoSpec.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the Future CI package.
+ * Future CI is licensed under MIT (https://github.com/f500/future-ci/blob/master/LICENSE).
+ */
+
+namespace spec\F500\CI\Build;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * Class BuildInfoSpec
+ *
+ * @copyright 2014 Future500 B.V.
+ * @license   https://github.com/f500/future-ci/blob/master/LICENSE MIT
+ * @package   spec\F500\CI\Build
+ */
+class BuildInfoSpec extends ObjectBehavior
+{
+
+    function it_is_initializable()
+    {
+        $this->beConstructedWith([]);
+        $this->shouldHaveType('F500\CI\Build\BuildInfo');
+    }
+
+    function it_contains_valid_data()
+    {
+        $rawInfo = [
+            'author' => 'Ramon',
+            'branch' => 'feature/some-shiny-feature',
+            'comment' => 'Comment about feature',
+            'compare' => 'https://github.com/Future500bv',
+            'repo' => 'repo-name',
+        ];
+        $this->beConstructedWith($rawInfo);
+
+        $this->getAuthor()->shouldReturn($rawInfo['author']);
+        $this->getBranch()->shouldReturn($rawInfo['branch']);
+        $this->getComment()->shouldReturn($rawInfo['comment']);
+        $this->getCompare()->shouldReturn($rawInfo['compare']);
+        $this->getRepo()->shouldReturn($rawInfo['repo']);
+    }
+
+    function it_always_returns_a_string()
+    {
+        $this->beConstructedWith([]);
+
+        $this->getAuthor()->shouldBeString();
+        $this->getBranch()->shouldBeString();
+        $this->getComment()->shouldBeString();
+        $this->getCompare()->shouldBeString();
+        $this->getRepo()->shouldBeString();
+    }
+
+}

--- a/spec/F500/CI/Build/StandardBuildSpec.php
+++ b/spec/F500/CI/Build/StandardBuildSpec.php
@@ -7,6 +7,7 @@
 
 namespace spec\F500\CI\Build;
 
+use F500\CI\Build\BuildInfo;
 use F500\CI\Suite\Suite;
 use F500\CI\Task\Task;
 use PhpSpec\ObjectBehavior;
@@ -35,7 +36,7 @@ class StandardBuildSpec extends ObjectBehavior
 }
 EOT;
 
-    function let(Suite $suite, Task $task)
+    function let(Suite $suite, Task $task, BuildInfo $buildInfo)
     {
         $suite->getCn()->willReturn('some_suite');
         $suite->getName()->willReturn('Some Suite');
@@ -43,7 +44,7 @@ EOT;
         $suite->toJson()->willReturn($this->suiteJson);
 
         /** @noinspection PhpParamsInspection */
-        $this->beConstructedWith($suite, '/path/to/builds');
+        $this->beConstructedWith($suite, '/path/to/builds', $buildInfo);
     }
 
     function it_is_initializable()

--- a/spec/F500/CI/Console/Helper/RunHelperSpec.php
+++ b/spec/F500/CI/Console/Helper/RunHelperSpec.php
@@ -48,7 +48,7 @@ class RunHelperSpec extends ObjectBehavior
         $input->getArgument('suite')->willReturn('some_suite.yml');
         $input->getArgument('params')->willReturn([]);
         
-        $input->getOption('build_info')->willReturn(null);
+        $input->getOption('build-info')->willReturn(null);
 
         $configurator->loadConfig(Argument::type('string'), null, Argument::type('array'))
             ->willReturn(
@@ -102,7 +102,7 @@ class RunHelperSpec extends ObjectBehavior
          * Build info is
          * ['aap' => 'noot']
          */
-        $input->getOption('build_info')->willReturn('eyJhYXAiOiJub290In0=');
+        $input->getOption('build-info')->willReturn('eyJhYXAiOiJub290In0=');
 
         $buildRunner->initialize(Argument::type('F500\CI\Build\Build'))
             ->willReturn(true)
@@ -119,7 +119,7 @@ class RunHelperSpec extends ObjectBehavior
 
     function it_fails_with_unencoded_build_info(InputInterface $input, OutputInterface $output)
     {
-        $input->getOption('build_info')->willReturn('not properly encoded');
+        $input->getOption('build-info')->willReturn('not properly encoded');
         
         $this->shouldThrow(\RuntimeException::class)
             ->during('execute', [$input, $output]);

--- a/spec/F500/CI/Event/Subscriber/SlackSubscriberSpec.php
+++ b/spec/F500/CI/Event/Subscriber/SlackSubscriberSpec.php
@@ -49,10 +49,11 @@ class SlackSubscriberSpec extends ObjectBehavior
         $task->getName()->willReturn(self::TASK_NAME);
         $build->getCn()->willReturn('a1b2c3d4');
         $build->getSuiteName()->willReturn('Some Suite');
-        $build->getSuiteRepo()->willReturn('future-ci');
-        $build->getSuiteAuthor()->willReturn('Remi Woler');
-        $build->getSuiteCommithash(8)->willReturn('f0e266b1');
-        $build->getSuiteComment()->willReturn('Some comment');
+        $build->getRepo()->willReturn('future-ci');
+        $build->getAuthor()->willReturn('Remi Woler');
+        $build->getBranch()->willReturn('feature/some-shiny-feature');
+        $build->getComment()->willReturn('Some comment');
+        $build->getCompare()->willReturn('https://github.com/Future500bv');
         $build->getTasks()->willReturn(array('some_task' => $task));
 
         $phlack->getMessageBuilder()->willReturn($mb);

--- a/spec/F500/CI/Runner/ConfiguratorSpec.php
+++ b/spec/F500/CI/Runner/ConfiguratorSpec.php
@@ -44,7 +44,10 @@ class ConfiguratorSpec extends ObjectBehavior
     ) {
         $stringArg = Argument::type('string');
 
-        $buildFactory->createBuild($stringArg, Argument::type('F500\CI\Suite\Suite'), $stringArg)->willReturn($build);
+        $buildFactory->createBuild(
+            $stringArg, Argument::type('F500\CI\Suite\Suite'), $stringArg, Argument::type('array')
+        )->willReturn($build);
+
         $suiteFactory->createSuite($stringArg, $stringArg, Argument::type('array'))->willReturn($suite);
         $taskFactory->createTask($stringArg, $stringArg)->willReturn($task);
         $resultParserFactory->createResultParser($stringArg, $stringArg)->willReturn($resultParser);
@@ -691,7 +694,7 @@ class ConfiguratorSpec extends ObjectBehavior
 
     function it_creates_a_build(Suite $suite)
     {
-        $this->createBuild('F500\CI\Build\StandardBuild', $suite)
-            ->shouldReturnAnInstanceOf('F500\CI\Build\Build');
+        $this->createBuild('F500\CI\Build\StandardBuild', $suite, [])
+             ->shouldReturnAnInstanceOf('F500\CI\Build\Build');
     }
 }

--- a/src/F500/CI/Build/Build.php
+++ b/src/F500/CI/Build/Build.php
@@ -20,10 +20,11 @@ interface Build
 {
 
     /**
-     * @param Suite  $suite
+     * @param Suite $suite
      * @param string $buildsDir
+     * @param $buildInfo
      */
-    public function __construct(Suite $suite, $buildsDir);
+    public function __construct(Suite $suite, $buildsDir, BuildInfo $buildInfo);
 
     /**
      * @return string
@@ -63,21 +64,27 @@ interface Build
     /**
      * @return string
      */
-    public function getSuiteComment();
+    public function getAuthor();
 
     /**
      * @return string
      */
-    public function getSuiteAuthor();
+    public function getBranch();
 
     /**
      * @return string
      */
-    public function getSuiteRepo();
+    public function getComment();
 
     /**
-     * @param int $length
      * @return string
      */
-    public function getSuiteCommithash($length);
+    public function getCompare();
+
+    /**
+     * @return string
+     */
+    public function getRepo();
+
+
 }

--- a/src/F500/CI/Build/BuildFactory.php
+++ b/src/F500/CI/Build/BuildFactory.php
@@ -21,18 +21,18 @@ class BuildFactory
 
     /**
      * @param string $class
-     * @param Suite  $suite
+     * @param Suite $suite
      * @param string $buildsDir
+     * @param array $buildInfo
      * @return Build
-     * @throws \InvalidArgumentException
      */
-    public function createBuild($class, Suite $suite, $buildsDir)
+    public function createBuild($class, Suite $suite, $buildsDir, array $buildInfo)
     {
         if (!class_exists($class)) {
             throw new \InvalidArgumentException(sprintf('Cannot create build, class "%s" does not exist.', $class));
         }
-
-        $build = new $class($suite, $buildsDir);
+        
+        $build = new $class($suite, $buildsDir, new BuildInfo($buildInfo));
 
         if (!$build instanceof Build) {
             throw new \InvalidArgumentException(

--- a/src/F500/CI/Build/BuildInfo.php
+++ b/src/F500/CI/Build/BuildInfo.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This file is part of the Future CI package.
+ * Future CI is licensed under MIT (https://github.com/f500/future-ci/blob/master/LICENSE).
+ */
+
+namespace F500\CI\Build;
+
+/**
+ * Class BuildInfo
+ *
+ * @copyright 2016 Future500 B.V.
+ * @license   https://github.com/f500/future-ci/blob/master/LICENSE MIT
+ * @package   F500\CI\Build
+ */
+class BuildInfo
+{
+    /**
+     * @var string
+     */
+    private $author;
+    private $branch;
+    private $comment;
+    private $compare;
+    private $repo;
+
+    /**
+     * BuildInfo constructor.
+     * @param array $buildInfo
+     */
+    public function __construct(array $buildInfo)
+    {
+        $this->author  = isset($buildInfo['author']) ? (string)$buildInfo['author'] : '';
+        $this->branch  = isset($buildInfo['branch']) ? (string)$buildInfo['branch'] : '';
+        $this->comment = isset($buildInfo['comment']) ? (string)$buildInfo['comment'] : '';
+        $this->compare = isset($buildInfo['compare']) ? (string)$buildInfo['compare'] : '';
+        $this->repo    = isset($buildInfo['repo']) ? (string)$buildInfo['repo'] : '';
+    }
+
+    /**
+     * @return string
+     */
+    public function getAuthor()
+    {
+        return $this->author;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBranch()
+    {
+        return $this->branch;
+    }
+
+    /**
+     * @return string
+     */
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCompare()
+    {
+        return $this->compare;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRepo()
+    {
+        return $this->repo;
+    }
+
+}

--- a/src/F500/CI/Build/StandardBuild.php
+++ b/src/F500/CI/Build/StandardBuild.php
@@ -34,16 +34,22 @@ class StandardBuild implements Build
      * @var Suite
      */
     protected $suite;
+    /**
+     * @var BuildInfo
+     */
+    private $buildInfo;
 
     /**
-     * @param Suite  $suite
+     * @param Suite $suite
      * @param string $buildsDir
+     * @param BuildInfo $buildInfo
      */
-    public function __construct(Suite $suite, $buildsDir)
+    public function __construct(Suite $suite, $buildsDir, BuildInfo $buildInfo)
     {
-        $this->date     = new \DateTimeImmutable();
-        $this->suite    = $suite;
-        $this->buildDir = sprintf('%s/%s/%s', $buildsDir, $this->getSuiteCn(), $this->getCn());
+        $this->date      = new \DateTimeImmutable();
+        $this->suite     = $suite;
+        $this->buildDir  = sprintf('%s/%s/%s', $buildsDir, $this->getSuiteCn(), $this->getCn());
+        $this->buildInfo = $buildInfo;
     }
 
     /**
@@ -109,23 +115,29 @@ class StandardBuild implements Build
         return $this->suite->toJson();
     }
 
-    public function getSuiteComment()
+    public function getAuthor()
     {
-        return $this->suite->getComment();
+        return $this->buildInfo->getAuthor();
     }
 
-    public function getSuiteAuthor()
+    public function getBranch()
     {
-        return $this->suite->getAuthor();
+        return $this->buildInfo->getBranch();
     }
 
-    public function getSuiteRepo()
+    public function getComment()
     {
-        return $this->suite->getRepo();
+        return $this->buildInfo->getComment();
     }
 
-    public function getSuiteCommithash($length)
+    public function getCompare()
     {
-        return $this->suite->getCommithash($length);
+        return $this->buildInfo->getCompare();
     }
+
+    public function getRepo()
+    {
+        return $this->buildInfo->getRepo();
+    }
+
 }

--- a/src/F500/CI/Console/Command/QueueWorkerCommand.php
+++ b/src/F500/CI/Console/Command/QueueWorkerCommand.php
@@ -69,7 +69,7 @@ class QueueWorkerCommand extends QueueCommand
                 $args = array('exec', 'app/console', '--ansi', 'run', $payload['suite']);
 
                 if (!empty($payload['params'])) {
-                    $args[] = "--build_info " . base64_encode(json_encode($payload['params']));
+                    $args[] = "--build-info " . base64_encode(json_encode($payload['params']));
                 }
                 
                 $process = $processFactory->createProcess($args, $rootDir, null, null, 1200);

--- a/src/F500/CI/Console/Command/RunCommand.php
+++ b/src/F500/CI/Console/Command/RunCommand.php
@@ -13,6 +13,7 @@ use F500\CI\Event\Subscriber\SlackSubscriber;
 use F500\CI\Event\Subscriber\TimerSubscriber;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -39,17 +40,23 @@ class RunCommand extends Command
                 'params',
                 InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
                 'Extra parameters for the suite. (key:value)'
+            )
+            ->addOption(
+                'build_info',
+                'b',
+                InputOption::VALUE_REQUIRED,
+                'Extra infornation for the build. (base64 encoded json)'
             );
     }
 
     /**
-     * @param InputInterface  $input
+     * @param InputInterface $input
      * @param OutputInterface $output
      */
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
         $dispatcher = $this->getService('dispatcher');
-        $phlack     = $this->getService('phlack');
+        $phlack = $this->getService('phlack');
 
         $dispatcher->addSubscriber(new SlackSubscriber($phlack));
         $dispatcher->addSubscriber(new ConsoleOutputSubscriber($output));
@@ -57,7 +64,7 @@ class RunCommand extends Command
     }
 
     /**
-     * @param InputInterface  $input
+     * @param InputInterface $input
      * @param OutputInterface $output
      * @return void
      * @throws \RuntimeException

--- a/src/F500/CI/Console/Command/RunCommand.php
+++ b/src/F500/CI/Console/Command/RunCommand.php
@@ -42,7 +42,7 @@ class RunCommand extends Command
                 'Extra parameters for the suite. (key:value)'
             )
             ->addOption(
-                'build_info',
+                'build-info',
                 'b',
                 InputOption::VALUE_REQUIRED,
                 'Extra infornation for the build. (base64 encoded json)'

--- a/src/F500/CI/Console/Helper/RunHelper.php
+++ b/src/F500/CI/Console/Helper/RunHelper.php
@@ -62,7 +62,7 @@ class RunHelper
         }
 
         $buildInfo = array();
-        foreach ($this->unpackBuildInfo($input->getOption('build_info')) as $name => $value) {
+        foreach ($this->unpackBuildInfo($input->getOption('build-info')) as $name => $value) {
             $buildInfo[$name] = $value;
         }
 

--- a/src/F500/CI/Console/Helper/RunHelper.php
+++ b/src/F500/CI/Console/Helper/RunHelper.php
@@ -61,6 +61,11 @@ class RunHelper
             $params[$split[0]] = $split[1];
         }
 
+        $buildInfo = array();
+        foreach ($this->unpackBuildInfo($input->getOption('build_info')) as $name => $value) {
+            $buildInfo[$name] = $value;
+        }
+
         try {
             $config = $configurator->loadConfig($filename, null, $params);
         } catch (\InvalidArgumentException $e) {
@@ -70,7 +75,7 @@ class RunHelper
         }
 
         $suite = $configurator->createSuite($config['suite']['class'], $config['suite']['cn'], $config);
-        $build = $configurator->createBuild($config['build']['class'], $suite);
+        $build = $configurator->createBuild($config['build']['class'], $suite, $buildInfo);
 
         $result = new Result($build, $filesystem);
 
@@ -83,5 +88,22 @@ class RunHelper
         if (!$buildRunner->cleanup($build, $result)) {
             $output->writeln("<fg=magenta>\xE2\x9C\x98 Cleaning up build failed!</fg=magenta>");
         }
+    }
+
+    private function unpackBuildInfo($encodedBuildInfo)
+    {
+        if ($encodedBuildInfo === null) {
+            return [];
+        }
+
+        if (!$encodedBuildInfo = base64_decode($encodedBuildInfo)) {
+            throw new \RuntimeException(sprintf('Build info should be base64 encoded.', $encodedBuildInfo));
+        }
+
+        if (!$encodedBuildInfo = json_decode($encodedBuildInfo)) {
+            throw new \RuntimeException(sprintf('Build info is not valid json.', $encodedBuildInfo));
+        }
+
+        return $encodedBuildInfo;
     }
 }

--- a/src/F500/CI/Runner/Configurator.php
+++ b/src/F500/CI/Runner/Configurator.php
@@ -183,12 +183,13 @@ class Configurator
 
     /**
      * @param string $class
-     * @param Suite  $suite
+     * @param Suite $suite
+     * @param array $buildInfo
      * @return Build
      */
-    public function createBuild($class, Suite $suite)
+    public function createBuild($class, Suite $suite, array $buildInfo)
     {
-        $build = $this->buildFactory->createBuild($class, $suite, $this->buildsDir);
+        $build = $this->buildFactory->createBuild($class, $suite, $this->buildsDir, $buildInfo);
 
         return $build;
     }

--- a/src/F500/CI/Suite/StandardSuite.php
+++ b/src/F500/CI/Suite/StandardSuite.php
@@ -149,36 +149,4 @@ class StandardSuite implements Suite
             JSON_PRETTY_PRINT
         );
     }
-
-    public function getComment()
-    {
-        if (!isset($this->config['comment'])) {
-            return '';
-        }
-        return $this->config['comment'];
-    }
-
-    public function getAuthor()
-    {
-        if (!isset($this->config['author'])) {
-            return '';
-        }
-        return $this->config['author'];
-    }
-
-    public function getRepo()
-    {
-        if (!isset($this->config['repo'])) {
-            return '';
-        }
-        return $this->config['repo'];
-    }
-
-    public function getCommithash($length = 40)
-    {
-        if (!isset($this->config['branch'])) {
-            return '';
-        }
-        return substr($this->config['branch'], 0, $length);
-    }
 }

--- a/src/F500/CI/Suite/Suite.php
+++ b/src/F500/CI/Suite/Suite.php
@@ -75,24 +75,4 @@ interface Suite
      */
     public function toJson();
 
-    /**
-     * @return string
-     */
-    public function getComment();
-
-    /**
-     * @return string
-     */
-    public function getAuthor();
-
-    /**
-     * @return string
-     */
-    public function getRepo();
-
-    /**
-     * @param int $length
-     * @return string
-     */
-    public function getCommithash($length);
 }


### PR DESCRIPTION
This change introduces individual build information, added to the constructor of a build.
It's done in the form of a type-hinted object `buildInfo`.

Any information sent through the githook in the `params` key will be encoded and added as a "build_information" option to the `RunCommand`. There, it is added to the build and later used in (for example) the SlackSubscriber.
